### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,4 +1,6 @@
 name: PR Validation
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/Alteriom/alteriom-mqtt-schema/security/code-scanning/12](https://github.com/Alteriom/alteriom-mqtt-schema/security/code-scanning/12)

To fix this error while maintaining all current workflow functionality, add an explicit `permissions` block at the root of `.github/workflows/pr-validation.yml`. Since all jobs only need to read repository content and do not write to the repository or interact with issues/PRs, the minimal permission needed is `contents: read`. Add the following block directly after the workflow `name:` key and before the `on:` block:
```yaml
permissions:
  contents: read
```
This sets the least privilege needed for the workflow and applies to all jobs unless further granular permissions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
