### PR TITLE
fix: add code 403 to envelope, verify HTTP transport and schema completeness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 > **Note**: For detailed schema-level changes and comprehensive version history, see [docs/mqtt_schema/CHANGELOG.md](./docs/mqtt_schema/CHANGELOG.md)
 
+## [0.8.2] - 2026-03-28
+
+### Added
+- **CONFIG_SET_RESPONSE (code 403)**: New schema, validator, and enum entry for firmware response to CONFIG_SET_COMMAND (Type 402)
+- **Three-way alignment**: Schema library verified aligned with alteriom-firmware and painlessMesh repos
+- **HTTP transport verification**: Confirmed `transport_metadata` support with 13 integration tests
+- **Full coverage for codes 600-614**: Verified all bridge management codes have corresponding schema files
+
+### Changed
+- Updated `MessageType` enum with `CONFIG_SET_RESPONSE: 403` entry
+- Updated envelope schema to include code 403 in valid message type codes
+
 ## [0.8.1] - 2025-11-11
 
 ### Changed
@@ -189,6 +201,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 | Version | Date | Type | Key Features |
 |---------|------|------|--------------|
+| 0.8.2 | 2026-03-28 | Patch | CONFIG_SET_RESPONSE (403), three-way alignment |
 | 0.8.1 | 2025-11-11 | Patch | PainlessMesh v1.8.2 compatibility |
 | 0.8.0 | 2025-11-08 | Major | Unified firmware, bridge management, HTTP transport |
 | 0.7.3 | 2025-10-30 | Minor | Message batching, compression, code quality tools |

--- a/README.md
+++ b/README.md
@@ -752,6 +752,7 @@ For performance optimization and standardized routing, use the optional `message
 | 400 | `COMMAND` | command | control | Device control command |
 | 401 | `COMMAND_RESPONSE` | command_response | control | Command execution result |
 | 402 | `CONTROL_RESPONSE` | control_response | control | Legacy control response (deprecated) |
+| 403 | `CONFIG_SET_RESPONSE` | config_set_response | control | Firmware response to CONFIG_SET_COMMAND (v0.8.2+) |
 
 ### Firmware & OTA
 

--- a/docs/mqtt_schema/CHANGELOG.md
+++ b/docs/mqtt_schema/CHANGELOG.md
@@ -1,5 +1,16 @@
 # MQTT Schema Artifacts Changelog
 
+## 2026-03-28 (v0.8.2 - Three-Way Alignment + CONFIG_SET_RESPONSE)
+
+### New Schema
+- **CONFIG_SET_RESPONSE (403)** — firmware response to config set commands with status, section, applied_config, requires_restart, backup_created fields
+
+### Alignment
+- Three-way consistency audit with alteriom-firmware and painlessMesh repos
+- Verified all codes 600-614 have corresponding schema files
+- Verified HTTP transport support is schema-agnostic (13 integration tests)
+- Confirmed code 250 is NOT in schema (firmware migrating to 614)
+
 ## 2025-11-11 (v0.8.1 - PainlessMesh v1.8.2 Compatibility Verification)
 
 ### Compatibility Update: PainlessMesh v1.8.2 Support Verified

--- a/docs/mqtt_schema/config_set_response.schema.json
+++ b/docs/mqtt_schema/config_set_response.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.alteriom.io/mqtt/v1/config_set_response.schema.json",
+  "title": "Config Set Response v1",
+  "description": "Response from device after a configuration set command (Type 403). Sent by firmware after applying CONFIG_SET_COMMAND (Type 402).",
+  "allOf": [{"$ref": "envelope.schema.json"}],
+  "type": "object",
+  "properties": {
+    "message_type": {
+      "const": 403,
+      "description": "Message type code for config set response (v0.8.1+)"
+    },
+    "correlation_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "description": "Matches correlation_id from original CONFIG_SET_COMMAND (Type 402)"
+    },
+    "result": {
+      "type": "object",
+      "description": "Result of the configuration set operation",
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["ok", "partial", "error", "rejected"],
+          "description": "Outcome of the config set operation"
+        },
+        "section": {
+          "type": "string",
+          "maxLength": 64,
+          "description": "Configuration section that was targeted (e.g., 'network', 'sensors', 'ota')"
+        },
+        "applied_config": {
+          "type": "object",
+          "description": "The configuration values that were successfully applied",
+          "additionalProperties": true
+        },
+        "requires_restart": {
+          "type": "boolean",
+          "description": "Whether the device needs to restart for changes to take effect"
+        },
+        "backup_created": {
+          "type": "boolean",
+          "description": "Whether a configuration backup was created before applying changes"
+        },
+        "error_code": {
+          "type": "string",
+          "maxLength": 64,
+          "description": "Machine-readable error code if status is error or rejected"
+        },
+        "error_message": {
+          "type": "string",
+          "maxLength": 256,
+          "description": "Human-readable error description"
+        }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/docs/mqtt_schema/envelope.schema.json
+++ b/docs/mqtt_schema/envelope.schema.json
@@ -9,7 +9,7 @@
     "message_type": {
       "type": "integer",
       "description": "Optional message type code for fast classification (v0.7.2+, v0.8.0 adds 10x unified range). Legacy codes 300,301 supported during migration.",
-      "enum": [101, 102, 103, 104, 105, 200, 201, 202, 203, 204, 300, 301, 302, 303, 304, 305, 306, 400, 401, 402, 500, 600, 601, 602, 603, 604, 605, 610, 611, 612, 613, 614, 700, 800, 810]
+      "enum": [101, 102, 103, 104, 105, 200, 201, 202, 203, 204, 300, 301, 302, 303, 304, 305, 306, 400, 401, 402, 403, 500, 600, 601, 602, 603, 604, 605, 610, 611, 612, 613, 614, 700, 800, 810]
     },
     "device_id": {"type": "string", "minLength": 1, "maxLength": 64, "pattern": "^[A-Za-z0-9_-]+$"},
     "device_type": {"type": "string", "enum": ["sensor", "gateway", "bridge", "hybrid"]},

--- a/docs/mqtt_schema/types.ts
+++ b/docs/mqtt_schema/types.ts
@@ -35,6 +35,7 @@ export const MessageTypeCodes = {
   COMMAND: 400,
   COMMAND_RESPONSE: 401,
   CONTROL_RESPONSE: 402,      // deprecated
+  CONFIG_SET_RESPONSE: 403,   // v0.8.1 - firmware response to CONFIG_SET_COMMAND (Type 402)
   
   // Firmware Updates
   FIRMWARE_STATUS: 500,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alteriom/mqtt-schema",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Alteriom MQTT v1 schemas, TypeScript types, and validation helpers for web integration",
   "license": "MIT",
   "author": "Alteriom Development Team",

--- a/scripts/copy-schemas.cjs
+++ b/scripts/copy-schemas.cjs
@@ -40,6 +40,7 @@ const copyList = [
   'control_response.schema.json',
   'command.schema.json',
   'command_response.schema.json',
+  'config_set_response.schema.json', // v0.8.1
   // Mesh Network
   'mesh_node_list.schema.json',
   'mesh_topology.schema.json',

--- a/src/schemas/config_set_response.schema.json
+++ b/src/schemas/config_set_response.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.alteriom.io/mqtt/v1/config_set_response.schema.json",
+  "title": "Config Set Response v1",
+  "description": "Response from device after a configuration set command (Type 403). Sent by firmware after applying CONFIG_SET_COMMAND (Type 402).",
+  "allOf": [{"$ref": "envelope.schema.json"}],
+  "type": "object",
+  "properties": {
+    "message_type": {
+      "const": 403,
+      "description": "Message type code for config set response (v0.8.1+)"
+    },
+    "correlation_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "description": "Matches correlation_id from original CONFIG_SET_COMMAND (Type 402)"
+    },
+    "result": {
+      "type": "object",
+      "description": "Result of the configuration set operation",
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["ok", "partial", "error", "rejected"],
+          "description": "Outcome of the config set operation"
+        },
+        "section": {
+          "type": "string",
+          "maxLength": 64,
+          "description": "Configuration section that was targeted (e.g., 'network', 'sensors', 'ota')"
+        },
+        "applied_config": {
+          "type": "object",
+          "description": "The configuration values that were successfully applied",
+          "additionalProperties": true
+        },
+        "requires_restart": {
+          "type": "boolean",
+          "description": "Whether the device needs to restart for changes to take effect"
+        },
+        "backup_created": {
+          "type": "boolean",
+          "description": "Whether a configuration backup was created before applying changes"
+        },
+        "error_code": {
+          "type": "string",
+          "maxLength": 64,
+          "description": "Machine-readable error code if status is error or rejected"
+        },
+        "error_message": {
+          "type": "string",
+          "maxLength": 256,
+          "description": "Human-readable error description"
+        }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/src/schemas/envelope.schema.json
+++ b/src/schemas/envelope.schema.json
@@ -9,7 +9,7 @@
     "message_type": {
       "type": "integer",
       "description": "Optional message type code for fast classification (v0.7.2+, v0.8.0 adds 10x unified range). Legacy codes 300,301 supported during migration.",
-      "enum": [101, 102, 103, 104, 105, 200, 201, 202, 203, 204, 300, 301, 302, 303, 304, 305, 306, 400, 401, 402, 500, 600, 601, 602, 603, 604, 605, 610, 611, 612, 613, 614, 700, 800, 810]
+      "enum": [101, 102, 103, 104, 105, 200, 201, 202, 203, 204, 300, 301, 302, 303, 304, 305, 306, 400, 401, 402, 403, 500, 600, 601, 602, 603, 604, 605, 610, 611, 612, 613, 614, 700, 800, 810]
     },
     "device_id": {"type": "string", "minLength": 1, "maxLength": 64, "pattern": "^[A-Za-z0-9_-]+$"},
     "device_type": {"type": "string", "enum": ["sensor", "gateway", "bridge", "hybrid"]},

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -26,6 +26,7 @@ import {
   control_response_schema,
   command_schema,
   command_response_schema,
+  config_set_response_schema,
   // Mesh Network
   mesh_node_list_schema,
   mesh_topology_schema,
@@ -70,6 +71,7 @@ const firmwareStatus = firmware_status_schema as any;
 const controlResponse = control_response_schema as any;
 const command = command_schema as any;
 const commandResponse = command_response_schema as any;
+const configSetResponse = config_set_response_schema as any;
 // Mesh Network
 const meshNodeList = mesh_node_list_schema as any;
 const meshTopology = mesh_topology_schema as any;
@@ -144,6 +146,7 @@ const firmwareStatusValidate = ajv.compile(firmwareStatus);
 const controlResponseValidate = ajv.compile(controlResponse);
 const commandValidate = ajv.compile(command);
 const commandResponseValidate = ajv.compile(commandResponse);
+const configSetResponseValidate = ajv.compile(configSetResponse);
 // Mesh Network Validators
 const meshNodeListValidate = ajv.compile(meshNodeList);
 const meshTopologyValidate = ajv.compile(meshTopology);
@@ -186,6 +189,7 @@ export const validators = {
   controlResponse: (d: unknown) => toResult(controlResponseValidate, d),
   command: (d: unknown) => toResult(commandValidate, d),
   commandResponse: (d: unknown) => toResult(commandResponseValidate, d),
+  configSetResponse: (d: unknown) => toResult(configSetResponseValidate, d),
   // Mesh Network Validators
   meshNodeList: (d: unknown) => toResult(meshNodeListValidate, d),
   meshTopology: (d: unknown) => toResult(meshTopologyValidate, d),
@@ -241,6 +245,7 @@ const MESSAGE_TYPE_MAP: Record<number, ValidatorName> = {
   400: 'command',
   401: 'commandResponse',
   402: 'controlResponse',
+  403: 'configSetResponse', // v0.8.1 - CONFIG_SET_RESPONSE from firmware
   // Firmware Updates
   500: 'firmwareStatus',
   // Mesh Network


### PR DESCRIPTION
Part of three-way alignment between mqtt-schema, firmware, and painlessMesh.

- Add CONFIG_SET_RESPONSE (403) to envelope message_type enum + validator + schema file
- Verified HTTP transport support is complete (transport_metadata, 13 integration tests)
- Verified all codes 600-614 have corresponding schema files
- Confirmed code 250 is NOT in enum (firmware must migrate to 614)

Related PRs: Alteriom/alteriom-firmware (type code alignment), Alteriom/painlessMesh (MpptPackage collision fix)